### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Googkit
 =======
 
 
-.. image:: https://pypip.in/version/googkit/badge.svg
+.. image:: https://img.shields.io/pypi/v/googkit.svg
    :target: https://crate.io/packages/googkit
 
 .. image:: https://travis-ci.org/googkit/googkit.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20googkit))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `googkit`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.